### PR TITLE
Implementation of customizable message format.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.github.ShindouMihou</groupId>
             <artifactId>amatsuki</artifactId>
-            <version>1.2.5r1</version>
+            <version>1.2.6r1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>pw.mihou</groupId>
     <artifactId>Amelia</artifactId>
     <description>A basic, and simple Discord bot for reading authors' or users' RSS from ScribbleHub.</description>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 
     <repositories>
         <repository>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.github.ShindouMihou</groupId>
             <artifactId>amatsuki</artifactId>
-            <version>1.2.6r1</version>
+            <version>1.2.6r2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/pw/mihou/amelia/commands/db/MessageDB.java
+++ b/src/main/java/pw/mihou/amelia/commands/db/MessageDB.java
@@ -1,0 +1,69 @@
+package pw.mihou.amelia.commands.db;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import org.bson.Document;
+import pw.mihou.amelia.db.MongoDB;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MessageDB {
+
+    private static final Map<Long, String> messageCache = new HashMap<>();
+    private static final MongoCollection<Document> db = MongoDB.collection("formats", "amelia");
+
+    public static String setFormat(long server, String message){
+        Document doc = new Document("server", server).append("message", message);
+
+        // Same for the one below but except for DB.
+        if(doesExist(server)){
+            db.replaceOne(Filters.eq("server", server), doc);
+        } else {
+            db.insertOne(doc);
+        }
+
+        // If the format already exists for server then we replace it.
+        if(messageCache.containsKey(server)){
+            messageCache.replace(server, message);
+        } else {
+            messageCache.put(server, message);
+        }
+
+        return message;
+    }
+
+    public static String requestFormat(long server){
+        if(!doesExist(server))
+            return setFormat(server, "\uD83D\uDCD6 **{title} by {author}**\n{link}\n\n{subscribed}");
+
+        String message = db.find(Filters.eq("server", server)).first().getString("message");
+
+        // Update our cache...
+        if(messageCache.containsKey(server)){
+            messageCache.replace(server, message);
+        } else {
+            messageCache.put(server, message);
+        }
+
+        return message;
+    }
+
+    /**
+     * Retrieves from cache if possible, else retrieve from database.
+     * @param server the server.
+     * @return message format.
+     */
+    public static String getFormat(long server){
+        if(!messageCache.containsKey(server))
+            return requestFormat(server);
+
+        return messageCache.get(server);
+    }
+
+    private static boolean doesExist(long server){
+        return db.find(Filters.eq("server", server)).first() != null;
+    }
+
+
+}

--- a/src/main/java/pw/mihou/amelia/commands/settings/Settings.java
+++ b/src/main/java/pw/mihou/amelia/commands/settings/Settings.java
@@ -8,6 +8,7 @@ import org.javacord.api.entity.user.User;
 import org.javacord.api.event.message.MessageCreateEvent;
 import pw.mihou.amelia.commands.base.Command;
 import pw.mihou.amelia.commands.base.db.ServerDB;
+import pw.mihou.amelia.commands.db.MessageDB;
 import pw.mihou.amelia.models.ServerModel;
 import pw.mihou.amelia.templates.Embed;
 import pw.mihou.amelia.templates.Message;
@@ -65,6 +66,19 @@ public class Settings extends Command {
                             Message.msg("Error: Invalid arguments.").send(event.getChannel());
                         }
                     }
+                } else if(args[1].equalsIgnoreCase("message")){
+                    if(args.length > 2){
+                        String message = event.getMessageContent().replaceFirst(args[0] + " " + args[1] + " ", "");
+                        MessageDB.setFormat(server.getId(), message);
+                        Message.msg("The message format has now been changed.").send(event.getChannel());
+                    } else {
+                        Message.msg("Error: Please type the message you wish to use for all feeds. \n" +
+                                "**Placeholders**" +
+                                "\n- **{title}**, the title of the chapter." +
+                                "\n- **{author}**, the author of the story." +
+                                "\n- **{link}**, the link to the chapter." +
+                                "\n- **{subscribed}**, mentions of all subscribed roles.").send(event.getChannel());
+                    }
                 }
             } else {
               Message.msg(embed(server)).send(event.getChannel());
@@ -80,6 +94,7 @@ public class Settings extends Command {
                 .setDescription("Here are your current server settings.")
                 .build().addInlineField("Limit", (model.getLimit() ? "`Active`" : "`Inactive (WARNING)`"))
                 .addInlineField("Prefix", "`"+model.getPrefix()+"`")
-                .addInlineField("`RSS Manager Role`", (model.getRole().isPresent() ? server.getRoleById(model.getRole().get()).map(Role::getMentionTag).orElse("`Disabled`") : "`Disabled`"));
+                .addInlineField("RSS Manager Role", (model.getRole().isPresent() ? server.getRoleById(model.getRole().get()).map(Role::getMentionTag).orElse("`Disabled`") : "`Disabled`"))
+                .addField("Message Format", MessageDB.getFormat(server.getId()));
     }
 }

--- a/src/main/java/pw/mihou/amelia/commands/test/TestCommand.java
+++ b/src/main/java/pw/mihou/amelia/commands/test/TestCommand.java
@@ -6,6 +6,7 @@ import org.javacord.api.entity.user.User;
 import org.javacord.api.event.message.MessageCreateEvent;
 import pw.mihou.amelia.commands.base.Command;
 import pw.mihou.amelia.commands.db.FeedDB;
+import pw.mihou.amelia.commands.db.MessageDB;
 import pw.mihou.amelia.io.rome.ReadRSS;
 import pw.mihou.amelia.templates.Message;
 
@@ -27,8 +28,10 @@ public class TestCommand extends Command {
                     FeedDB.getServer(server.getId()).getChannel(event.getChannel().getId()).getFeedModel(id).ifPresentOrElse(feedModel ->
                                     ReadRSS.getLatest(feedModel.getFeedURL()).ifPresentOrElse(syndEntry ->
                              server.getTextChannelById(feedModel.getChannel()).ifPresentOrElse(tc ->
-                             Message.msg("\uD83D\uDCD6 **"+syndEntry.getTitle()+" by "+syndEntry.getAuthor()+".**" +
-                            "\n"+syndEntry.getLink()+"\n\n"+getMentions(feedModel.getMentions(), server)).send(tc),
+                                     // Replace all placeholders ahead of time.
+                                     Message.msg(MessageDB.requestFormat(tc.getServer().getId()).replaceAll("\\{title}", syndEntry.getTitle())
+                                             .replaceAll("\\{author}", syndEntry.getAuthor()).replaceAll("\\{link}", syndEntry.getLink())
+                                             .replaceAll("\\{subscribed}", getMentions(feedModel.getMentions(), tc.getServer()))).send(tc),
                             () -> Message.msg("Error: The channel provided does not exist.").send(event.getChannel())),
                             () -> Message.msg("Error: We couldn't connect to ScribbleHub's RSS feed, please try again later.").send(event.getChannel())),
                             () -> Message.msg("We couldn't find the feed, are you sure you are using the feed's unique ID?").send(event.getChannel()));


### PR DESCRIPTION
Added support for customizing the default feed format which was `:book: **{title} by {author}**\n{link}\n{subscribed}`. You can now customize it to anything even to the ones without the format. For example, you can set it to `{author} has updated their story: {link}` or some sort.