### PR TITLE
[Cache RSS Feeds]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>pw.mihou</groupId>
             <artifactId>amatsuki</artifactId>
-            <version>v1.2.9r1</version>
+            <version>4537a90d4f</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/pw/mihou/amelia/commands/notifier/AuthorCommand.java
+++ b/src/main/java/pw/mihou/amelia/commands/notifier/AuthorCommand.java
@@ -8,7 +8,6 @@ import pw.mihou.amelia.commands.base.Command;
 import pw.mihou.amelia.db.UserDB;
 import pw.mihou.amelia.models.SHUser;
 import pw.mihou.amelia.templates.Embed;
-
 import java.util.Collection;
 
 public class AuthorCommand extends Command {

--- a/src/main/java/pw/mihou/amelia/commands/test/TestCommand.java
+++ b/src/main/java/pw/mihou/amelia/commands/test/TestCommand.java
@@ -4,14 +4,14 @@ import org.javacord.api.entity.permission.Role;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.event.message.MessageCreateEvent;
+import pw.mihou.amelia.Amelia;
 import pw.mihou.amelia.commands.base.Command;
 import pw.mihou.amelia.commands.db.FeedDB;
-import pw.mihou.amelia.commands.db.MessageDB;
-import pw.mihou.amelia.io.StoryHandler;
 import pw.mihou.amelia.io.rome.ReadRSS;
 import pw.mihou.amelia.templates.Message;
 
 import java.util.ArrayList;
+import java.util.Optional;
 
 public class TestCommand extends Command {
 
@@ -27,23 +27,16 @@ public class TestCommand extends Command {
                 try {
                     long id = Long.parseLong(args[1]);
                     if (FeedDB.validate(id)) {
-                        FeedDB.getServer(server.getId()).getChannel(event.getChannel().getId()).getFeedModel(id).ifPresentOrElse(feedModel ->
+                        event.getMessage().reply("Please wait...").thenAccept(msg -> FeedDB.getServer(server.getId()).getChannel(event.getChannel().getId()).getFeedModel(id).ifPresentOrElse(feedModel ->
                                         ReadRSS.getLatest(feedModel.getFeedURL()).ifPresentOrElse(syndEntry ->
                                                         server.getTextChannelById(feedModel.getChannel()).ifPresentOrElse(tc ->
-                                                                        Message.msg(MessageDB.getFormat(tc.getServer().getId())
-                                                                                .replaceAll("\\{title}", syndEntry.getTitle())
-                                                                                .replaceAll("\\{author}", StoryHandler.getAuthor(syndEntry.getAuthor(), feedModel.getId()))
-                                                                                .replaceAll("\\{link}", syndEntry.getLink())
-                                                                                .replaceAll("\\{subscribed}", getMentions(feedModel.getMentions(), tc.getServer()))).send(tc).whenComplete((message, throwable) -> {
-                                                                            if (throwable != null) {
-                                                                                event.getMessage().reply("Error: A throwable was thrown, the bot possibly cannot send a message to the channel.");
-                                                                            } else {
-                                                                                event.getMessage().reply("The test went well!");
-                                                                            }
-                                                                        }),
-                                                                () -> event.getMessage().reply("Error: The channel provided does not exist.")),
-                                                () -> event.getMessage().reply("Error: We couldn't connect to ScribbleHub's RSS feed, please try again later.")),
-                                () -> event.getMessage().reply("We couldn't find the feed, are you sure you are using the feed's unique ID?"));
+                                                                Message.msg(Amelia.format(syndEntry, feedModel, server)).send(tc)
+                                                                        .whenComplete((message, throwable) -> Optional.ofNullable(throwable).ifPresentOrElse(t -> msg.delete().thenAccept(unused ->
+                                                                                        event.getMessage().reply("Error: A throwable was thrown, the bot possibly cannot send a message to the channel.")),
+                                                                                () -> msg.delete().thenAccept(u -> event.getMessage().reply("The test went well!")))),
+                                                                () -> msg.delete().thenAccept(u -> event.getMessage().reply("Error: The channel provided does not exist."))),
+                                                () -> msg.delete().thenAccept(unused -> msg.delete().thenAccept(u -> event.getMessage().reply("Error: We couldn't connect to ScribbleHub's RSS feed, please try again later.")))),
+                                () -> msg.delete().thenAccept(unused -> event.getMessage().reply("We couldn't find the feed, are you sure you are using the feed's unique ID?"))));
                     } else {
                         event.getMessage().reply("Error: We couldn't find the feed, are you sure you are using the feed's unique id." +
                                 "\nPlease verify using `feeds`");

--- a/src/main/java/pw/mihou/amelia/io/rome/ReadRSS.java
+++ b/src/main/java/pw/mihou/amelia/io/rome/ReadRSS.java
@@ -1,6 +1,7 @@
 package pw.mihou.amelia.io.rome;
 
 import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndEntryImpl;
 import com.rometools.rome.io.FeedException;
 import com.rometools.rome.io.SyndFeedInput;
 import com.rometools.rome.io.XmlReader;
@@ -9,15 +10,31 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import pw.mihou.amelia.io.Terminal;
+import tk.mihou.amatsuki.impl.cache.CacheManager;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 public class ReadRSS {
 
-    public static Optional<SyndEntry> getLatest(String url) {
-        try (CloseableHttpClient client = HttpClients.createMinimal()) {
+    private static final String format_cache = "AMELIA_FEEDS_%s_CACHE";
+
+    public static Optional<SyndEntry> getLatest(String url){
+        if(CacheManager.isCached(String.format(format_cache, url))){
+            SyndEntry result = CacheManager.getCache(SyndEntryImpl.class, String.format(format_cache, url));
+            if(result != null){
+                return Optional.of(result);
+            }
+        }
+
+        return requestLatest(url).map(syndEntry -> CacheManager.addCache(syndEntry, String.format(format_cache, url), 5, TimeUnit.MINUTES));
+    }
+
+    public static Optional<SyndEntry> requestLatest(String url) {
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
             HttpUriRequest request = new HttpGet(url);
             request.setHeader("User-Agent", "Amelia/1.0r1 (Language=Java/1.8, Developer=Shindou Mihou)");
             try (CloseableHttpResponse response = client.execute(request);

--- a/src/main/java/pw/mihou/amelia/io/rome/ReadRSS.java
+++ b/src/main/java/pw/mihou/amelia/io/rome/ReadRSS.java
@@ -30,7 +30,8 @@ public class ReadRSS {
             }
         }
 
-        return requestLatest(url).map(syndEntry -> CacheManager.addCache(syndEntry, String.format(format_cache, url), 5, TimeUnit.MINUTES));
+        // We only need this cache when sending the same story to the channels that have the same one.
+        return requestLatest(url).map(syndEntry -> CacheManager.addCache(syndEntry, String.format(format_cache, url), 2, TimeUnit.MINUTES));
     }
 
     public static Optional<SyndEntry> requestLatest(String url) {


### PR DESCRIPTION
This will cache all RSS feeds (for 2 minutes which is enough time to send the same results to all servers who are fetching from a certain story).

Previous method:
Get all feeds -> Request to SH (even if another server has the same feed) -> Parse -> send to server.

New Method:
Get all feeds -> Check if it is on Cache -> (If it is: Parse then send to server) : (If it isn't: Request from SH, parse then send to server).

Why is caching feeds best?
- It reduces the load on both Amelia & ScribbleHub.
- Best for this case since we have multiple stories that are on multiple servers, so we'd end up requesting the same RSS feed for each of those servers, example: A Liliful World is on 3 channels on server x, and also on 5 channels on server y, Amelia then sends 8 requests to SH for the same feed on A Liliful World which you can already tell is spammy and inefficient.

What the cache does is simplify those requests, so we only have to request once for each story (with a cache lifespan of 2 minutes which allows us to keep up to date during each scheduled time, 2 minutes since that is the maximum time the scheduler should run).